### PR TITLE
Release 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,29 @@ Payments are processed offsite at [Billplz](https://billplz.com) and the custome
 
 ### Changelog
 
-#### 1.2.0 - January 07, 2024
-* New: Added the option to send email confirmation on payment success.
-* New: Enabled the ability to select multiple forms as payment forms.
-* New: Introduced the new `bcf7_payment_success` action hook.
-* Improvement: Refactored codebase for better organization.
+#### 1.3.0 - April 29, 2026
+* New: Failed payments now appear in the payments admin tab and have their own Failed view filter.
+* New: The example payment form created on activation is automatically selected as the active payment form.
+* Security: Verified Billplz signature inside the payment confirmation shortcode so crafted URLs can no longer expose another payer's details.
+* Security: Required a capability check and bulk-action nonce on the payments admin table before deleting or marking entries completed.
+* Security: Escaped the transaction ID link in the payments admin table.
+* Security: Verified the paid amount reported by Billplz against the recorded bill before marking a payment completed.
+* Security: Sanitized API, general, and email settings on save, including X-Signature key and email body input.
+* Security: Hardened the credentials notice to escape its admin URL and run a capability check.
+* Improvement: Payment redirect now works with Contact Form 7's Ajax submission flow.
+* Improvement: Billplz callback completion is now idempotent, so repeated callbacks cannot reprocess the same payment.
+* Improvement: Confirmation email now sends as HTML with the correct Content-Type header and escapes transaction placeholders.
+* Improvement: Payments admin table now uses the site timezone for the Submitted and Paid columns.
+* Fix: Stopped writing the 0000-00-00 zero datetime to paid_at, which failed under MySQL strict mode.
+* Compatibility: Tested up to WordPress 6.9.
+
+#### 1.2.1 - July 14, 2025
+* Security: Fixed XSS vulnerability in admin area payment table links.
+
+#### 1.2 - March 30, 2023
+* New: Added option to send email confirmation on payment success.
+* New: Added ability to select multiple forms as payment forms.
+* Improvement: Codebase refactoring for better organization.
 
 #### 1.0.2 - December 24, 2022
 * New: Display current mode status (Live / Test) on the dashboard's admin bar.

--- a/app/Admin/PaymentTable.php
+++ b/app/Admin/PaymentTable.php
@@ -171,20 +171,23 @@ class PaymentTable extends WP_List_Table {
 	protected function get_views() {
 		$completed = $this->get_status_count( 'completed' );
 		$pending   = $this->get_status_count( 'pending' );
+		$failed    = $this->get_status_count( 'failed' );
 
 		$status_links = array(
-			'all'       => __( "<a class='" . ( ( ! isset( $_GET['status'] ) ) ? 'current' : '' ) . "' href='" . esc_url( remove_query_arg( 'status' ) ) . "'>All <span class='count'>(" . ( $completed + $pending ) . ')</span></a>', BCF7_TEXT_DOMAIN ),
+			'all'       => __( "<a class='" . ( ( ! isset( $_GET['status'] ) ) ? 'current' : '' ) . "' href='" . esc_url( remove_query_arg( 'status' ) ) . "'>All <span class='count'>(" . ( $completed + $pending + $failed ) . ')</span></a>', BCF7_TEXT_DOMAIN ),
 
 			'completed' => __( "<a class='" . ( ( isset( $_GET['status'] ) && ( $_GET['status'] == 'completed' ) ) ? 'current' : '' ) . "' href='" . esc_url( add_query_arg( 'status', 'completed' ) ) . "'>Completed <span class='count'>(" . $completed . ')</span></a>', BCF7_TEXT_DOMAIN ),
 
 			'pending'   => __( "<a class='" . ( ( isset( $_GET['status'] ) && ( $_GET['status'] == 'pending' ) ) ? 'current' : '' ) . "' href='" . esc_url( add_query_arg( 'status', 'pending' ) ) . "'>Pending <span class='count'>(" . $pending . ')</span></a>', BCF7_TEXT_DOMAIN ),
+
+			'failed'    => __( "<a class='" . ( ( isset( $_GET['status'] ) && ( $_GET['status'] == 'failed' ) ) ? 'current' : '' ) . "' href='" . esc_url( add_query_arg( 'status', 'failed' ) ) . "'>Failed <span class='count'>(" . $failed . ')</span></a>', BCF7_TEXT_DOMAIN ),
 		);
 		return $status_links;
 	}
 
 	public function get_status_count( $status ) {
 		global $wpdb;
-		$count = $wpdb->get_var( "SELECT COUNT(*) FROM {$this->get_db_name()} WHERE status = '$status'" );
+		$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$this->get_db_name()} WHERE status = %s", $status ) );
 		return $count;
 	}
 }

--- a/app/Admin/PaymentTable.php
+++ b/app/Admin/PaymentTable.php
@@ -9,6 +9,14 @@ class PaymentTable extends WP_List_Table {
 	// Define $table_data property
 	private $table_data;
 
+	public function __construct() {
+		parent::__construct( array(
+			'singular' => 'bcf7_payment',
+			'plural'   => 'bcf7_payments',
+			'ajax'     => false,
+		) );
+	}
+
 	// The database table name
 	private function get_db_name() {
 		global $wpdb;
@@ -42,9 +50,13 @@ class PaymentTable extends WP_List_Table {
 					'customer'       => $payment_data['name'],
 					'form'           => $payment_data['form_title'] . ' (ID: ' . $payment_data['form_id'] . ')',
 					'amount'         => $payment_data['amount'],
-					'transaction_id' => '<a href=' . $payment_data['bill_url'] . " target='_blank'>" . $payment_data['transaction_id'] . '</a>',
-					'created_at'     => nl2br( "Submitted on \n " . date( 'F j, Y \a\t\ g:i a', strtotime( $payment_data['created_at'] ) ) . ' ' ),
-					'paid_at'        => ( '0000-00-00 00:00:00' != $payment_data['paid_at'] ) ? ( nl2br( "Paid on \n " . date( 'F j, Y \a\t\ g:i a', strtotime( $payment_data['paid_at'] ) ) . ' ' ) ) : '-',
+					'transaction_id' => sprintf(
+						'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+						esc_url( $payment_data['bill_url'] ),
+						esc_html( $payment_data['transaction_id'] )
+					),
+					'created_at'     => nl2br( "Submitted on \n " . wp_date( 'F j, Y \a\t\ g:i a', strtotime( $payment_data['created_at'] ) ) . ' ' ),
+					'paid_at'        => ( ! empty( $payment_data['paid_at'] ) && '0000-00-00 00:00:00' !== $payment_data['paid_at'] ) ? nl2br( "Paid on \n " . wp_date( 'F j, Y \a\t\ g:i a', strtotime( $payment_data['paid_at'] ) ) . ' ' ) : '-',
 					'status'         => ucfirst( $payment_data['status'] ),
 				);
 			}
@@ -136,31 +148,39 @@ class PaymentTable extends WP_List_Table {
 	public function process_bulk_action() {
 		$action = $this->current_action();
 
-		if ( 'delete' === $action ) {
-			$list_ids = map_deep( $_POST['payment_id'], 'sanitize_text_field' );
+		if ( 'delete' !== $action && 'mark_as_completed' !== $action ) {
+			return;
+		}
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage payments.', BCF7_TEXT_DOMAIN ) );
+		}
+
+		check_admin_referer( 'bulk-' . $this->_args['plural'] );
+
+		$raw_ids  = isset( $_POST['payment_id'] ) ? (array) $_POST['payment_id'] : array();
+		$list_ids = array_values( array_filter( array_map( 'absint', $raw_ids ) ) );
+
+		if ( empty( $list_ids ) ) {
+			return;
+		}
+
+		global $wpdb;
+
+		if ( 'delete' === $action ) {
 			foreach ( $list_ids as $id ) {
-				global $wpdb;
-				$sql = $wpdb->prepare( "DELETE FROM {$this->get_db_name()} WHERE id= %d", array( $id ) );
-				$wpdb->query( $sql );
+				$wpdb->query( $wpdb->prepare( "DELETE FROM {$this->get_db_name()} WHERE id = %d", $id ) );
 			}
 			$text = ( count( $list_ids ) > 1 ) ? 'payments' : 'payment';
-
 			add_action( 'admin_notices', $this->bulk_action_notice( count( $list_ids ), $text, 'deleted' ) );
-			$this->table_data;
 		}
 
 		if ( 'mark_as_completed' === $action ) {
-			$list_ids = map_deep( $_POST['payment_id'], 'sanitize_text_field' );
-
 			foreach ( $list_ids as $id ) {
-				global $wpdb;
-				$wpdb->update( $this->get_db_name(), array( 'status' => 'completed' ), array( 'ID' => $id ) );
+				$wpdb->update( $this->get_db_name(), array( 'status' => 'completed' ), array( 'id' => $id ), array( '%s' ), array( '%d' ) );
 			}
-
 			$text = ( count( $list_ids ) > 1 ) ? 'payments' : 'payment';
 			add_action( 'admin_notices', $this->bulk_action_notice( count( $list_ids ), $text, 'updated' ) );
-			$this->table_data;
 		}
 	}
 

--- a/app/Base/Activate.php
+++ b/app/Base/Activate.php
@@ -82,11 +82,14 @@ class Activate {
 		$query = new WP_Query( $args );
 
 		if ( $query->have_posts() ) {
+			$form_id = (int) $query->posts[0]->ID;
 			wp_reset_postdata();
-			return null;
+			$this->save_form_id($form_id);
+			return $form_id;
 		} else {
 			$form_id = $this->insert_form($form_title, $form_content);
 			$this->add_form_meta($form_id);
+			$this->save_form_id($form_id);
 			return $form_id;
 		}
 	}
@@ -138,6 +141,41 @@ class Activate {
             );
             add_option('bcf7_general_settings', $options);
         }
+    }
+
+    /**
+     * Method to save the example payment form ID in the options table.
+     *
+     * @param int $form_id The ID of the form.
+     *
+     * @return void
+     */
+    private function save_form_id($form_id) {
+        if (empty($form_id)) {
+            return;
+        }
+
+        $options = get_option('bcf7_general_settings');
+
+        if (! is_array($options)) {
+            $options = array(
+                'bcf7_mode'          => '1',
+                'bcf7_form_select'   => array($form_id),
+                'bcf7_redirect_page' => '',
+            );
+
+            add_option('bcf7_general_settings', $options);
+            return;
+        }
+
+        $selected_forms = isset($options['bcf7_form_select']) ? array_filter(array_map('intval', (array) $options['bcf7_form_select'])) : array();
+
+        if (! empty($selected_forms)) {
+            return;
+        }
+
+        $options['bcf7_form_select'] = array($form_id);
+        update_option('bcf7_general_settings', $options);
     }
 
     /**

--- a/app/Helpers/EmailConfirmation.php
+++ b/app/Helpers/EmailConfirmation.php
@@ -7,17 +7,18 @@ class EmailConfirmation {
   private const EMAIL_SUBJECT_OPTION = 'bcf7_email_subject';
   private const EMAIL_BODY_OPTION = 'bcf7_email_body';
 
-  private array $options;
+  private array $options = array();
 
   /**
    * Email confirmation constructor.
    */
   public function __construct() {
-	  if ( null != get_option( self::EMAIL_SETTINGS_OPTION )) {
-		$this->options = get_option( self::EMAIL_SETTINGS_OPTION );
-	  }
+    $stored = get_option( self::EMAIL_SETTINGS_OPTION );
+    if ( is_array( $stored ) ) {
+      $this->options = $stored;
+    }
   }
-  
+
 
   /**
    * Sends email confirmation.
@@ -25,12 +26,17 @@ class EmailConfirmation {
    * @param array $transaction Transaction details.
    */
   public function send( array $transaction ): void {
-    $to = $transaction['customer_email'];
-    $subject = $this->options[ self::EMAIL_SUBJECT_OPTION ];
-    $body = $this->options[ self::EMAIL_BODY_OPTION ];
+    $to      = isset( $transaction['customer_email'] ) ? $transaction['customer_email'] : '';
+    $subject = isset( $this->options[ self::EMAIL_SUBJECT_OPTION ] ) ? $this->options[ self::EMAIL_SUBJECT_OPTION ] : '';
+    $body    = isset( $this->options[ self::EMAIL_BODY_OPTION ] ) ? $this->options[ self::EMAIL_BODY_OPTION ] : '';
+
+    if ( '' === $to || '' === $subject || '' === $body ) {
+      return;
+    }
+
     $body = $this->replace_variables_in_email_body( $body, $transaction );
 
-    wp_mail( $to, $subject, $body );
+    wp_mail( $to, $subject, $body, array( 'Content-Type: text/html; charset=UTF-8' ) );
   }
 
   /**
@@ -42,11 +48,11 @@ class EmailConfirmation {
    * @return string Modified email body.
    */
   private function replace_variables_in_email_body( string $body, array $transaction ): string {
-    $date = date( 'F j, Y', strtotime( $transaction['txn_date'] ) );
-    $body = str_replace( '{customer_name}', $transaction['customer_name'], $body );
-    $body = str_replace( '{transaction_id}', $transaction['txn_id'], $body );
-    $body = str_replace( '{transaction_date}', $date, $body );
-    $body = str_replace( '{transaction_amount}', 'RM ' . $transaction['txn_amount'], $body );
+    $date = ! empty( $transaction['txn_date'] ) ? wp_date( 'F j, Y', strtotime( $transaction['txn_date'] ) ) : '';
+    $body = str_replace( '{customer_name}', esc_html( (string) ( $transaction['customer_name'] ?? '' ) ), $body );
+    $body = str_replace( '{transaction_id}', esc_html( (string) ( $transaction['txn_id'] ?? '' ) ), $body );
+    $body = str_replace( '{transaction_date}', esc_html( $date ), $body );
+    $body = str_replace( '{transaction_amount}', 'RM ' . esc_html( number_format( (float) ( $transaction['txn_amount'] ?? 0 ), 2 ) ), $body );
     return $body;
   }
 }

--- a/app/Helpers/Functions.php
+++ b/app/Helpers/Functions.php
@@ -16,13 +16,17 @@ class Functions
 
   public function general_option($key = '', $default = false)
   {
-    $value = !empty(get_option('bcf7_general_settings')[$key]) ? get_option('bcf7_general_settings')[$key] : $default;
+    $options = get_option('bcf7_general_settings', array());
+    $value = (is_array($options) && array_key_exists($key, $options) && '' !== $options[$key]) ? $options[$key] : $default;
+
     return $value;
   }
 
   public function api_option($key = '', $default = false)
   {
-    $value = !empty(get_option('bcf7_api_options')[$key]) ? get_option('bcf7_api_options')[$key] : $default;
+    $options = get_option('bcf7_api_options', array());
+    $value = (is_array($options) && array_key_exists($key, $options) && '' !== $options[$key]) ? $options[$key] : $default;
+
     return $value;
   }
 
@@ -44,8 +48,8 @@ class Functions
 
   public function get_api_key()
   {
-    $live    = base64_encode($this->api_option("bcf7_live_secret_key"));
-    $sandbox = base64_encode($this->api_option("bcf7_sandbox_secret_key"));
+    $live    = base64_encode($this->api_option("bcf7_live_secret_key") . ':');
+    $sandbox = base64_encode($this->api_option("bcf7_sandbox_secret_key") . ':');
 
     $api_key = ("Live" == $this->get_mode()) ? $live : $sandbox;
 

--- a/app/Payment/CallbackHandler.php
+++ b/app/Payment/CallbackHandler.php
@@ -84,7 +84,7 @@ class CallbackHandler
       return;
     }
 
-    if ('true' === $query_params['paid'] && ! $this->paid_amount_matches($payment_id, $query_params)) {
+    if ('true' === $query_params['paid'] && ! $this->paid_amount_matches($payment_id, sanitize_text_field($query_params['id']), $query_params)) {
       return;
     }
 
@@ -96,9 +96,9 @@ class CallbackHandler
     );
   }
 
-  private function paid_amount_matches($payment_id, $query_params)
+  private function paid_amount_matches($payment_id, $transaction_id, $query_params)
   {
-    $payment = $this->get_payment($payment_id);
+    $payment = $this->get_payment($payment_id, $transaction_id);
 
     if (! $payment) {
       return false;
@@ -185,7 +185,7 @@ class CallbackHandler
       return false;
     }
 
-    $payment = $this->get_payment($payment_id);
+    $payment = $this->get_payment($payment_id, $transaction_id);
 
     if (! $payment) {
       return false;
@@ -199,12 +199,12 @@ class CallbackHandler
     if ('true' === $paid) {
       $updated = $wpdb->query(
         $wpdb->prepare(
-          "UPDATE {$table_name} SET status = %s, transaction_id = %s, paid_at = %s, bill_url = %s WHERE id = %d AND status != %s",
+          "UPDATE {$table_name} SET status = %s, paid_at = %s, bill_url = %s WHERE id = %d AND transaction_id = %s AND status != %s",
           'completed',
-          $transaction_id,
           $paid_at,
           $bill_url,
           $payment_id,
+          $transaction_id,
           'completed'
         )
       );
@@ -228,21 +228,31 @@ class CallbackHandler
 
     $wpdb->query(
       $wpdb->prepare(
-        "UPDATE {$table_name} SET transaction_id = %s, paid_at = NULL, bill_url = %s WHERE id = %d",
-        $transaction_id,
+        "UPDATE {$table_name} SET paid_at = NULL, bill_url = %s WHERE id = %d AND transaction_id = %s",
         $bill_url,
-        $payment_id
+        $payment_id,
+        $transaction_id
       )
     );
 
     return true;
   }
 
-  private function get_payment($payment_id)
+  private function get_payment($payment_id, $transaction_id = null)
   {
     global $wpdb;
 
     $table_name = $wpdb->prefix . "bcf7_payment";
+
+    if (null !== $transaction_id) {
+      return $wpdb->get_row(
+        $wpdb->prepare(
+          "SELECT name, email, amount, status FROM {$table_name} WHERE id = %d AND transaction_id = %s",
+          $payment_id,
+          $transaction_id
+        )
+      );
+    }
 
     return $wpdb->get_row($wpdb->prepare("SELECT name, email, amount, status FROM {$table_name} WHERE id = %d", $payment_id));
   }

--- a/app/Payment/CallbackHandler.php
+++ b/app/Payment/CallbackHandler.php
@@ -226,14 +226,13 @@ class CallbackHandler
       return true;
     }
 
-    $wpdb->update(
-      $table_name,
-      array(
-        'transaction_id' => $transaction_id,
-        'paid_at' => null,
-        'bill_url' => $bill_url
-      ),
-      array('id' => $payment_id)
+    $wpdb->query(
+      $wpdb->prepare(
+        "UPDATE {$table_name} SET transaction_id = %s, paid_at = NULL, bill_url = %s WHERE id = %d",
+        $transaction_id,
+        $bill_url,
+        $payment_id
+      )
     );
 
     return true;

--- a/app/Payment/CallbackHandler.php
+++ b/app/Payment/CallbackHandler.php
@@ -84,12 +84,30 @@ class CallbackHandler
       return;
     }
 
+    if ('true' === $query_params['paid'] && ! $this->paid_amount_matches($payment_id, $query_params)) {
+      return;
+    }
+
     $this->handle_payment_update(
       $payment_id,
       sanitize_text_field($query_params['id']),
       sanitize_text_field($query_params['paid']),
       isset($query_params['paid_at']) ? sanitize_text_field($query_params['paid_at']) : ''
     );
+  }
+
+  private function paid_amount_matches($payment_id, $query_params)
+  {
+    $payment = $this->get_payment($payment_id);
+
+    if (! $payment) {
+      return false;
+    }
+
+    $expected_cents = (int) round(((float) $payment->amount) * 100);
+    $reported_cents = isset($query_params['paid_amount']) ? (int) $query_params['paid_amount'] : 0;
+
+    return $expected_cents > 0 && $expected_cents === $reported_cents;
   }
 
   private function is_billplz_listener()
@@ -212,7 +230,7 @@ class CallbackHandler
       $table_name,
       array(
         'transaction_id' => $transaction_id,
-        'paid_at' => '0000-00-00 00:00:00',
+        'paid_at' => null,
         'bill_url' => $bill_url
       ),
       array('id' => $payment_id)

--- a/app/Payment/CallbackHandler.php
+++ b/app/Payment/CallbackHandler.php
@@ -23,167 +23,210 @@ class CallbackHandler
   public function send_email($transactions)
   {
     $option = get_option('bcf7_email_settings');
-    if ($option && '1' == $option['bcf7_email_permission']) {
+    if (is_array($option) && isset($option['bcf7_email_permission']) && '1' == $option['bcf7_email_permission']) {
       (new EmailConfirmation())->send( $transactions );
     }
   }
   
   public function redirect()
   {
-    if (empty($_GET) and (!isset($query['bcf7-listener']))) return;
-
-    if (isset($_GET['bcf7-listener']) and ("billplz" == $_GET['bcf7-listener'])) {
-
-      global $wpdb;
-
-      $table_name = $wpdb->prefix . "bcf7_payment";
-
-      $query = $wpdb->get_results($wpdb->prepare("SELECT name, email, amount, status FROM {$table_name} WHERE id= %d", array($_GET['payment-id'])));
-
-      $name = get_object_vars($query[0])['name'];
-      $email = get_object_vars($query[0])['email'];
-      $amount = get_object_vars($query[0])['amount'];
-      $status = get_object_vars($query[0])['status'];
-
-      if ("completed" == $status) return;
+    if (! $this->is_billplz_listener()) {
+      return;
     }
 
-    $x_signature = $this->helpers->get_xsignature();
-    $url         = htmlentities($_SERVER['QUERY_STRING']);
+    $url = isset($_SERVER['QUERY_STRING']) ? html_entity_decode((string) $_SERVER['QUERY_STRING']) : '';
 
-    parse_str(html_entity_decode($url), $query);
+    parse_str($url, $query);
 
-    ksort($query);
+    if (! $this->has_redirect_payload($query)) {
+      return;
+    }
 
-    $payment_id     = isset($query['payment-id']) ? $query['payment-id'] : "";
-    $transaction_id = isset($query['billplz']['id']) ? $query['billplz']['id'] : "";
-    $paid_at        = isset($query['billplz']['paid_at']) ? $query['billplz']['paid_at'] : "";
-    $bill_url       = $this->helpers->get_url() . "/bills/" . $transaction_id;
-    $x_sign         = isset($query['billplz']['x_signature']) ? $query['billplz']['x_signature'] : "";
+    $x_sign = sanitize_text_field($query['billplz']['x_signature']);
+    $hash = $this->redirect_signature($query);
 
+    if (! $this->signatures_match($hash, $x_sign)) {
+      return;
+    }
+
+    $this->handle_payment_update(
+      absint($query['payment-id']),
+      sanitize_text_field($query['billplz']['id']),
+      sanitize_text_field($query['billplz']['paid']),
+      isset($query['billplz']['paid_at']) ? sanitize_text_field($query['billplz']['paid_at']) : ''
+    );
+  }
+
+  public function callback()
+  {
+    if (!isset($_SERVER['REQUEST_METHOD']) || $_SERVER['REQUEST_METHOD'] !== 'POST' || ! $this->is_billplz_listener()) {
+      return;
+    }
+
+    $query_string = file_get_contents('php://input');
+
+    parse_str($query_string, $query_params);
+
+    if (! $this->has_callback_payload($query_params)) {
+      return;
+    }
+
+    $payment_id = isset($_GET['payment-id']) ? absint($_GET['payment-id']) : 0;
+
+    if (! $payment_id) {
+      return;
+    }
+
+    $x_sign = sanitize_text_field($query_params['x_signature']);
+    $hash = $this->callback_signature($query_params);
+
+    if (! $this->signatures_match($hash, $x_sign)) {
+      return;
+    }
+
+    $this->handle_payment_update(
+      $payment_id,
+      sanitize_text_field($query_params['id']),
+      sanitize_text_field($query_params['paid']),
+      isset($query_params['paid_at']) ? sanitize_text_field($query_params['paid_at']) : ''
+    );
+  }
+
+  private function is_billplz_listener()
+  {
+    return isset($_GET['bcf7-listener']) && 'billplz' === $_GET['bcf7-listener'];
+  }
+
+  private function has_redirect_payload($query)
+  {
+    return (
+      isset($query['payment-id'], $query['billplz']) &&
+      is_array($query['billplz']) &&
+      ! empty($query['billplz']['id']) &&
+      isset($query['billplz']['paid']) &&
+      ! empty($query['billplz']['x_signature'])
+    );
+  }
+
+  private function has_callback_payload($query_params)
+  {
+    return (
+      ! empty($query_params['x_signature']) &&
+      ! empty($query_params['id']) &&
+      isset($query_params['paid'])
+    );
+  }
+
+  private function redirect_signature($query)
+  {
     unset($query['billplz']['x_signature']);
     unset($query['payment-id']);
     unset($query['bcf7-listener']);
     unset($query['page_id']);
 
-
-    $a = array();
+    $parts = array();
 
     foreach ($query as $key => $value) {
-      if (isset($value) && is_array($value)) {
+      if (is_array($value)) {
         foreach ($value as $sub_key => $sub_val) {
-          array_push($a, ($key . $sub_key . $sub_val));
+          $parts[] = $key . $sub_key . $sub_val;
         }
       }
     }
 
-    sort($a);
+    sort($parts);
 
-    $hash    = hash_hmac('sha256', implode("|", $a), $x_signature);
-
-    if (isset($_GET['bcf7-listener']) and ($hash == $x_sign) and ('true' == $query['billplz']['paid'])) {
-
-      $wpdb->update(
-        $table_name,
-        array(
-          'status' => 'completed',
-          'transaction_id' => $transaction_id,
-          'paid_at' => $paid_at,
-          'bill_url' => $bill_url
-        ),
-        array('ID' => $payment_id)
-      );
-	
-	 $transactions = array(
-        'customer_email' => $email,
-        'customer_name' => $name,
-        'txn_id' => $transaction_id,
-        'txn_date' => $paid_at,
-        'txn_amount' => $amount
-    ); 
-	
-	 do_action('bcf7_payment_success', $transactions);
-
-    } elseif ((isset($_GET['bcf7-listener'])) and ($hash == $x_sign) and ('false' == $query['billplz']['paid'])) {
-
-      $wpdb->update(
-        $table_name,
-        array(
-          'transaction_id' => $transaction_id,
-          'paid_at' => '0000-00-00 00:00:00',
-          'bill_url' => $bill_url
-        ),
-        array('ID' => $payment_id)
-      );
-    }
+    return hash_hmac('sha256', implode('|', $parts), $this->helpers->get_xsignature());
   }
 
-  public function callback()
+  private function callback_signature($query_params)
   {
-    if (!isset($_SERVER['REQUEST_METHOD'])) return;
+    unset($query_params['x_signature']);
 
-    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $parts = array();
 
-      $query_string = file_get_contents('php://input');
-
-      parse_str($query_string, $query_params);
-
-      if (
-        !isset($_GET['bcf7-listener']) and
-        empty($_GET['payment-id']) and
-        empty($query_params['x_signature']) and
-        empty($query_params['id']) and
-        empty($query_params['paid']) and
-        empty($query_params['paid_at']) and
-        empty($query_params['id'])
-      ) return;
-
-      $x_sign         = $query_params['x_signature'];
-      $x_sign2        = $this->helpers->get_xsignature();
-      $transaction_id = $query_params['id'];
-      $paid_at        = $query_params['paid_at'];
-      $bill_url       = $this->helpers->get_url() . "/bills/" . $transaction_id;
-      $payment_id     = $_GET['payment-id'];
-
-
-      ksort($query_params);
-      unset($query_params['x_signature']);
-
-      $a = array();
-      foreach ($query_params as $key => $value) {
-        array_push($a, ($key . $value));
-      }
-
-      sort($a);
-
-      $hash = hash_hmac('sha256', implode('|', $a), $x_sign2);
-
-      global $wpdb;
-      $table_name = $wpdb->prefix . "bcf7_payment";
-
-      if (isset($_GET['bcf7-listener']) and ($hash == $x_sign) and ("true" == $query_params['paid'])) {
-        $wpdb->update(
-          $table_name,
-          array(
-            'status' => 'completed',
-            'transaction_id' => $transaction_id,
-            'paid_at' => $paid_at,
-            'bill_url' => $bill_url
-          ),
-          array('ID' => $payment_id)
-        );
-      } elseif (isset($_GET['bcf7-listener']) and ($hash == $x_sign) and ("false" == $query_params['paid'])) {
-
-        $wpdb->update(
-          $table_name,
-          array(
-            'transaction_id' => $transaction_id,
-            'paid_at' => '0000-00-00 00:00:00',
-            'bill_url' => $bill_url
-          ),
-          array('ID' => $payment_id)
-        );
+    foreach ($query_params as $key => $value) {
+      if (is_scalar($value)) {
+        $parts[] = $key . $value;
       }
     }
+
+    sort($parts);
+
+    return hash_hmac('sha256', implode('|', $parts), $this->helpers->get_xsignature());
+  }
+
+  private function signatures_match($hash, $signature)
+  {
+    return is_string($signature) && hash_equals($hash, $signature);
+  }
+
+  private function handle_payment_update($payment_id, $transaction_id, $paid, $paid_at)
+  {
+    if (! $payment_id || '' === $transaction_id) {
+      return false;
+    }
+
+    $payment = $this->get_payment($payment_id);
+
+    if (! $payment) {
+      return false;
+    }
+
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . "bcf7_payment";
+    $bill_url = esc_url_raw($this->helpers->get_url() . "/bills/" . rawurlencode($transaction_id));
+
+    if ('true' === $paid) {
+      $updated = $wpdb->query(
+        $wpdb->prepare(
+          "UPDATE {$table_name} SET status = %s, transaction_id = %s, paid_at = %s, bill_url = %s WHERE id = %d AND status != %s",
+          'completed',
+          $transaction_id,
+          $paid_at,
+          $bill_url,
+          $payment_id,
+          'completed'
+        )
+      );
+
+      if ($updated > 0) {
+        do_action('bcf7_payment_success', array(
+          'customer_email' => $payment->email,
+          'customer_name' => $payment->name,
+          'txn_id' => $transaction_id,
+          'txn_date' => $paid_at,
+          'txn_amount' => $payment->amount
+        ));
+      }
+
+      return true;
+    }
+
+    if ('completed' === $payment->status) {
+      return true;
+    }
+
+    $wpdb->update(
+      $table_name,
+      array(
+        'transaction_id' => $transaction_id,
+        'paid_at' => '0000-00-00 00:00:00',
+        'bill_url' => $bill_url
+      ),
+      array('id' => $payment_id)
+    );
+
+    return true;
+  }
+
+  private function get_payment($payment_id)
+  {
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . "bcf7_payment";
+
+    return $wpdb->get_row($wpdb->prepare("SELECT name, email, amount, status FROM {$table_name} WHERE id = %d", $payment_id));
   }
 }

--- a/app/Payment/FormSubmission.php
+++ b/app/Payment/FormSubmission.php
@@ -123,7 +123,6 @@ class FormSubmission
         'mode'           => $mode,
         'status'         => $status,
         'created_at'     => current_time('mysql'),
-        'paid_at'        => null,
       ),
     );
 

--- a/app/Payment/FormSubmission.php
+++ b/app/Payment/FormSubmission.php
@@ -3,7 +3,7 @@
 namespace BillplzCF7\Payment;
 
 use BillplzCF7\Helpers\Functions;
-use Exception;
+use WP_Error;
 use WPCF7_Submission;
 
 class FormSubmission
@@ -17,39 +17,91 @@ class FormSubmission
 
   public function register()
   {
-    add_action('wpcf7_before_send_mail', array($this, 'process_data'));
-    add_filter('wpcf7_load_js', '__return_false');
+    add_action('wpcf7_before_send_mail', array($this, 'process_data'), 10, 3);
+    add_action('wp_enqueue_scripts', array($this, 'scripts'));
   }
 
-  public function process_data($contact_form)
+  public function scripts()
+  {
+    wp_enqueue_script(
+      'bcf7-payment-redirect',
+      BCF7_ASSETS_URL . 'js/payment-redirect.js',
+      array('contact-form-7'),
+      filemtime(BCF7_PLUGIN_PATH . 'assets/js/payment-redirect.js'),
+      true
+    );
+  }
+
+  public function process_data($contact_form, &$abort = false, $submission = null)
   {
     $id = $contact_form->id();
-    $list_of_forms = $this->helpers->general_option("bcf7_form_select");
 
-    $setting_url = admin_url('admin.php?page=billplz-cf7&tab=general-settings');
-    if (empty($list_of_forms)) wp_die("The payment form is not specified. Please go to the <a href='$setting_url'>General Settings options page</a> to set the form.");
-
-    if ( in_array( $id, $list_of_forms )) {
+    if (! $submission instanceof WPCF7_Submission) {
       $submission = WPCF7_Submission::get_instance();
-
-      if ( $submission && isset( $_POST['bcf7-amount'] ) ) {
-        $form_id        = $submission->get_contact_form()->id();
-        $form_title     = $submission->get_contact_form()->title();
-        $posted_data    = $submission->get_posted_data();
-        $name           = $posted_data['bcf7-name'];
-        $email          = $posted_data['bcf7-email'];
-        $amount         = $posted_data['bcf7-amount'];
-        $phone          = $posted_data['bcf7-phone'];
-        $transaction_id = '';
-        $mode           = $this->helpers->get_mode();
-        $status         = 'pending';
-
-        $payment_id = $this->record_data($form_id, $form_title, $name, $phone, $email, $amount, $transaction_id, $mode, $status);
-        
-        $description = apply_filters('bcf7_form_description', "Payment for $form_title");
-        $this->process_payment($name, $email, $phone, $amount, $description, $payment_id);
-      }
     }
+
+    if (! $submission) {
+      return;
+    }
+
+    if (! $this->is_payment_submission($id, $submission)) {
+      return;
+    }
+
+    $form_id    = $submission->get_contact_form()->id();
+    $form_title = $submission->get_contact_form()->title();
+    $name       = $this->posted_string($submission, 'bcf7-name');
+    $email      = $this->posted_string($submission, 'bcf7-email');
+    $amount     = $this->normalize_amount($submission->get_posted_data('bcf7-amount'));
+    $phone      = $this->posted_string($submission, 'bcf7-phone');
+
+    if ('' === $name || '' === $email || $amount <= 0) {
+      $this->abort_submission(
+        $submission,
+        $abort,
+        __('Payment form fields are incomplete. Please check the payment form setup.', BCF7_TEXT_DOMAIN)
+      );
+      return;
+    }
+
+    $payment_id = $this->record_data($form_id, $form_title, $name, $phone, $email, $amount, '', $this->helpers->get_mode(), 'pending');
+
+    if (! $payment_id) {
+      $this->abort_submission(
+        $submission,
+        $abort,
+        __('Unable to record the payment. Please try again later.', BCF7_TEXT_DOMAIN)
+      );
+      return;
+    }
+
+    $description = apply_filters('bcf7_form_description', "Payment for $form_title");
+    $bill = $this->process_payment($name, $email, $phone, $amount, $description, $payment_id);
+
+    if (is_wp_error($bill)) {
+      $this->mark_payment_failed($payment_id);
+      $this->abort_submission($submission, $abort, $bill->get_error_message());
+      return;
+    }
+
+    $this->update_bill_data($payment_id, $bill['id'], $bill['url']);
+
+    if (! $this->is_rest_request()) {
+      wp_redirect($bill['url']);
+      exit;
+    }
+
+    $submission->add_result_props(array(
+      'billplz' => array(
+        'payment_id'   => $payment_id,
+        'bill_id'      => $bill['id'],
+        'redirect_url' => $bill['url'],
+      ),
+    ));
+
+    $submission->set_status('payment_required');
+    $submission->set_response(__('Redirecting to Billplz...', BCF7_TEXT_DOMAIN));
+    $abort = true;
   }
 
   public function record_data($form_id, $form_title, $name, $phone, $email, $amount, $transaction_id, $mode, $status)
@@ -78,35 +130,152 @@ class FormSubmission
     return $wpdb->insert_id;
   }
 
+  public function update_bill_data($payment_id, $transaction_id, $bill_url)
+  {
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . "bcf7_payment";
+
+    $wpdb->update(
+      $table_name,
+      array(
+        'transaction_id' => $transaction_id,
+        'bill_url' => $bill_url,
+      ),
+      array('ID' => $payment_id)
+    );
+  }
+
+  public function mark_payment_failed($payment_id)
+  {
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . "bcf7_payment";
+
+    $wpdb->update(
+      $table_name,
+      array('status' => 'failed'),
+      array('ID' => $payment_id)
+    );
+  }
+
   public function process_payment($name, $email, $phone, $amount, $description, $payment_id)
   {
     $args = array(
       'headers' => array(
-        'Authorization' => 'Basic ' . $this->helpers->get_api_key() . ':',
+        'Authorization' => 'Basic ' . $this->helpers->get_api_key(),
       ),
       'body' => array(
         'collection_id' => $this->helpers->get_collection_id(),
         'email' => $email,
         'name' => $name,
-        'amount' => $amount * 100,
+        'amount' => (int) round($amount * 100),
         'mobile' => (isset($phone) ? $phone : ""),
         'redirect_url' => add_query_arg(array('bcf7-listener' => 'billplz', 'payment-id' => $payment_id), site_url("?page_id=" . $this->helpers->general_option('bcf7_redirect_page') . "")),
         'callback_url' => add_query_arg(array('bcf7-listener' => 'billplz', 'payment-id' => $payment_id), site_url('index.php')),
         'description' => $description
-      )
+      ),
+      'timeout' => 30,
     );
 
     $response = wp_remote_post($this->helpers->get_url() . "/api/v3/bills", $args);
-    $apiBody = json_decode(wp_remote_retrieve_body($response));
-    $bill_url = $apiBody->url;
 
-    if ($bill_url) {
-      $content = require_once BCF7_PLUGIN_PATH . "app/views/splash-page.php";
-      $content .= '<script>window.location.replace("' . $bill_url . '");</script>';
+    if (is_wp_error($response)) {
+      return new WP_Error(
+        'bcf7_billplz_request_failed',
+        __('Unable to connect to Billplz. Please try again later.', BCF7_TEXT_DOMAIN)
+      );
     }
 
-    $allowed_tags = array('div' => array(), 'p' => array(), 'script' => array());
+    $status_code = wp_remote_retrieve_response_code($response);
+    $api_body = json_decode(wp_remote_retrieve_body($response), true);
 
-    echo wp_kses($content, $allowed_tags);
+    if ($status_code < 200 || $status_code >= 300 || ! is_array($api_body)) {
+      return new WP_Error(
+        'bcf7_billplz_invalid_response',
+        __('Billplz could not create the payment bill. Please try again later.', BCF7_TEXT_DOMAIN)
+      );
+    }
+
+    $bill_url = isset($api_body['url']) ? esc_url_raw($api_body['url']) : '';
+    $bill_id = isset($api_body['id']) ? sanitize_text_field($api_body['id']) : '';
+
+    if ('' === $bill_id || '' === $bill_url || ! $this->is_valid_billplz_url($bill_url)) {
+      return new WP_Error(
+        'bcf7_billplz_missing_url',
+        __('Billplz returned an invalid payment URL. Please try again later.', BCF7_TEXT_DOMAIN)
+      );
+    }
+
+    return array(
+      'id' => $bill_id,
+      'url' => $bill_url,
+    );
+  }
+
+  private function abort_submission($submission, &$abort, $message)
+  {
+    $submission->set_status('aborted');
+    $submission->set_response($message);
+    $abort = true;
+  }
+
+  private function posted_string($submission, $name)
+  {
+    $value = $submission->get_posted_data($name);
+
+    if (is_array($value)) {
+      $value = reset($value);
+    }
+
+    return is_scalar($value) ? trim((string) $value) : '';
+  }
+
+  private function normalize_amount($value)
+  {
+    if (is_array($value)) {
+      $value = reset($value);
+    }
+
+    if (! is_scalar($value)) {
+      return 0;
+    }
+
+    $value = preg_replace('/[^0-9.]/', '', (string) $value);
+
+    return is_numeric($value) ? (float) $value : 0;
+  }
+
+  private function is_payment_submission($form_id, $submission)
+  {
+    $list_of_forms = $this->helpers->general_option('bcf7_form_select', array());
+    $list_of_forms = array_filter(array_map('intval', (array) $list_of_forms));
+
+    if (in_array((int) $form_id, $list_of_forms, true)) {
+      return true;
+    }
+
+    return null !== $submission->get_posted_data('bcf7-amount');
+  }
+
+  private function is_valid_billplz_url($url)
+  {
+    $expected = wp_parse_url($this->helpers->get_url());
+    $actual = wp_parse_url($url);
+
+    return (
+      isset($expected['host'], $actual['host'], $actual['scheme']) &&
+      'https' === $actual['scheme'] &&
+      $expected['host'] === $actual['host']
+    );
+  }
+
+  private function is_rest_request()
+  {
+    if (method_exists('WPCF7_Submission', 'is_restful')) {
+      return WPCF7_Submission::is_restful();
+    }
+
+    return defined('REST_REQUEST') && REST_REQUEST;
   }
 }

--- a/app/Payment/FormSubmission.php
+++ b/app/Payment/FormSubmission.php
@@ -123,7 +123,7 @@ class FormSubmission
         'mode'           => $mode,
         'status'         => $status,
         'created_at'     => current_time('mysql'),
-        'paid_at'        => '0000-00-00 00:00:00',
+        'paid_at'        => null,
       ),
     );
 

--- a/app/Payment/ProcessRedirect.php
+++ b/app/Payment/ProcessRedirect.php
@@ -28,15 +28,16 @@ class ProcessRedirect
     }
 
     $payment_id = absint($_GET['payment-id']);
+    $bill_id    = isset($_GET['billplz']['id']) ? sanitize_text_field($_GET['billplz']['id']) : '';
 
-    if (! $payment_id) {
+    if (! $payment_id || '' === $bill_id) {
       return '';
     }
 
     global $wpdb;
 
     $table_name = $wpdb->prefix . "bcf7_payment";
-    $data = $wpdb->get_row($wpdb->prepare("SELECT name, email, transaction_id, bill_url, status FROM {$table_name} WHERE id = %d", $payment_id), ARRAY_A);
+    $data = $wpdb->get_row($wpdb->prepare("SELECT name, email, transaction_id, bill_url, status FROM {$table_name} WHERE id = %d AND transaction_id = %s", $payment_id, $bill_id), ARRAY_A);
 
     if (! $data) {
       return '<p>' . esc_html__('Payment record not found.', BCF7_TEXT_DOMAIN) . '</p>';

--- a/app/Payment/ProcessRedirect.php
+++ b/app/Payment/ProcessRedirect.php
@@ -19,26 +19,36 @@ class ProcessRedirect
 
   public function redirect_callback()
   {
-    if ((empty($_GET) and (isset($_GET['bcf7-listener']) and "billplz" != $_GET['bcf7-listener'])) or (isset($_GET['post']) and isset($_GET['action']))) return;
+    if (! isset($_GET['bcf7-listener']) || "billplz" !== $_GET['bcf7-listener'] || empty($_GET['payment-id'])) {
+      return '';
+    }
 
-    if (isset($_GET['payment-id']) and "billplz" == $_GET['bcf7-listener']) {
-      $payment_id = $_GET['payment-id'];
+    $payment_id = absint($_GET['payment-id']);
 
-      global $wpdb;
+    if (! $payment_id) {
+      return '';
+    }
 
-      $table_name = $wpdb->prefix . "bcf7_payment";
+    global $wpdb;
 
-      $data = $wpdb->get_results($wpdb->prepare("SELECT name, email, transaction_id, bill_url, status FROM {$table_name} WHERE id= %d", array($payment_id)));
+    $table_name = $wpdb->prefix . "bcf7_payment";
+    $data = $wpdb->get_row($wpdb->prepare("SELECT name, email, transaction_id, bill_url, status FROM {$table_name} WHERE id = %d", $payment_id), ARRAY_A);
 
-      $data_array = get_object_vars($data[0]);
+    if (! $data) {
+      return '<p>' . esc_html__('Payment record not found.', BCF7_TEXT_DOMAIN) . '</p>';
+    }
 
-      $name   = $data_array['name'];
-      $email  = $data_array['email'];
-      $trx_id = $data_array['transaction_id'];
-      $bill   = $data_array['bill_url'];
-      $status = $data_array['status'];
+    $name   = $data['name'];
+    $email  = $data['email'];
+    $trx_id = $data['transaction_id'];
+    $bill   = $data['bill_url'];
+    $status = $data['status'];
+    $billplz = (isset($_GET['billplz']) && is_array($_GET['billplz'])) ? $_GET['billplz'] : array();
+    $is_paid_return = isset($billplz['paid']) && "true" === $billplz['paid'];
 
-      if ("completed" == $status) {
+    ob_start();
+
+    if ("completed" == $status) {
 ?>
         <h2>Thank you for your payment!</h2>
         <p>Payment ID: <?php echo esc_html($payment_id); ?></p>
@@ -47,21 +57,25 @@ class ProcessRedirect
         <p>Payment Status: <strong>Completed</strong></p>
         <p>Bill ID: <a href="<?php echo esc_url($bill); ?>" target="_blank"><?php echo esc_html($trx_id); ?></a></p>
       <?php
-      } elseif (("pending" == $status) and ("true" == $_GET['billplz']['paid'])) {
-        $bill_url = $this->helpers->get_url() . '/bills/' . ($_GET['billplz']['id']);
+    } elseif (("pending" == $status) && $is_paid_return) {
+        $bill_id = isset($billplz['id']) ? sanitize_text_field($billplz['id']) : '';
+        $bill_url = $bill_id ? $this->helpers->get_url() . '/bills/' . rawurlencode($bill_id) : $bill;
       ?>
         <h2>Something wrong. please contact site owner.</h2>
         <p>Payment Status: Unknown</p>
         <p>Please check your bill <a href="<?php echo esc_url($bill_url); ?>" target="_blank">here</a></p>
       <?php
 
-      } else {
+    } else {
       ?>
         <h2>Sorry, your payment was unsuccessful</h2>
         <p>Payment Status: Failed</p>
-        <p>Please repay the bill <a href="<?php echo esc_url($bill); ?>" target="_blank">here</a></p>
+        <?php if ($bill) : ?>
+          <p>Please repay the bill <a href="<?php echo esc_url($bill); ?>" target="_blank">here</a></p>
+        <?php endif; ?>
 <?php
-      }
     }
+
+    return ob_get_clean();
   }
 }

--- a/app/Payment/ProcessRedirect.php
+++ b/app/Payment/ProcessRedirect.php
@@ -23,6 +23,10 @@ class ProcessRedirect
       return '';
     }
 
+    if (! $this->verify_redirect_signature()) {
+      return '<p>' . esc_html__('Invalid or expired payment confirmation link.', BCF7_TEXT_DOMAIN) . '</p>';
+    }
+
     $payment_id = absint($_GET['payment-id']);
 
     if (! $payment_id) {
@@ -77,5 +81,40 @@ class ProcessRedirect
     }
 
     return ob_get_clean();
+  }
+
+  private function verify_redirect_signature()
+  {
+    $raw = isset($_SERVER['QUERY_STRING']) ? html_entity_decode((string) $_SERVER['QUERY_STRING']) : '';
+    parse_str($raw, $query);
+
+    if (empty($query['billplz']) || ! is_array($query['billplz']) || empty($query['billplz']['x_signature'])) {
+      return false;
+    }
+
+    $supplied = (string) $query['billplz']['x_signature'];
+
+    unset($query['billplz']['x_signature']);
+    unset($query['payment-id']);
+    unset($query['bcf7-listener']);
+    unset($query['page_id']);
+
+    $parts = array();
+
+    foreach ($query as $key => $value) {
+      if (is_array($value)) {
+        foreach ($value as $sub_key => $sub_val) {
+          if (is_scalar($sub_val)) {
+            $parts[] = $key . $sub_key . $sub_val;
+          }
+        }
+      }
+    }
+
+    sort($parts);
+
+    $expected = hash_hmac('sha256', implode('|', $parts), $this->helpers->get_xsignature());
+
+    return hash_equals($expected, $supplied);
   }
 }

--- a/app/Settings/API.php
+++ b/app/Settings/API.php
@@ -15,7 +15,9 @@ class API {
 	}
 
 	public function init() {
-		register_setting( 'bcf7_api', 'bcf7_api_options' );
+		register_setting( 'bcf7_api', 'bcf7_api_options', array(
+			'sanitize_callback' => array( $this, 'sanitize_options' ),
+		) );
 
 		add_settings_section(
 			'bcf7_live_section',
@@ -110,6 +112,28 @@ class API {
 		?>
 	<input class="regular-text" type="text" name="bcf7_api_options[bcf7_sandbox_collection_id]" id="bcf7_sandbox_collection_id" value="<?php echo esc_attr( isset( self::$options['bcf7_sandbox_collection_id'] ) ? self::$options['bcf7_sandbox_collection_id'] : '' ); ?>">
 		<?php
+	}
+
+	public function sanitize_options( $input ) {
+		if ( ! is_array( $input ) ) {
+			return array();
+		}
+
+		$keys = array(
+			'bcf7_live_secret_key',
+			'bcf7_live_collection_id',
+			'bcf7_live_xsignature_key',
+			'bcf7_sandbox_secret_key',
+			'bcf7_sandbox_collection_id',
+			'bcf7_sandbox_xsignature_key',
+		);
+
+		$clean = array();
+		foreach ( $keys as $key ) {
+			$clean[ $key ] = isset( $input[ $key ] ) ? sanitize_text_field( $input[ $key ] ) : '';
+		}
+
+		return $clean;
 	}
 
 	public function sandbox_xsignature_callback() {

--- a/app/Settings/Email.php
+++ b/app/Settings/Email.php
@@ -14,23 +14,30 @@ class Email
   public function register()
   {
     add_action('admin_init', array($this, "init"));
-    add_filter('pre_update_option_bcf7_email_settings', array($this, 'update_email_permission'));
   }
 
-  public function update_email_permission($new_value)
+  public function sanitize_options($input)
   {
-    if (!isset($new_value['bcf7_email_permission'])) {
-      $new_value['bcf7_email_permission'] = '';
+    if (! is_array($input)) {
+      return array();
     }
 
-    return $new_value;
+    $clean = array();
+    $clean['bcf7_email_permission'] = (isset($input['bcf7_email_permission']) && '1' === (string) $input['bcf7_email_permission']) ? '1' : '';
+    $clean['bcf7_email_subject'] = isset($input['bcf7_email_subject']) ? sanitize_text_field($input['bcf7_email_subject']) : '';
+    $clean['bcf7_email_body'] = isset($input['bcf7_email_body']) ? wp_kses_post($input['bcf7_email_body']) : '';
+
+    return $clean;
   }
 
   public function init()
   {
     register_setting(
       'bcf7_email',
-      'bcf7_email_settings'
+      'bcf7_email_settings',
+      array(
+        'sanitize_callback' => array($this, 'sanitize_options'),
+      )
     );
 
     add_settings_section(

--- a/app/Settings/General.php
+++ b/app/Settings/General.php
@@ -18,7 +18,9 @@ class General
 
   public function init()
   {
-    register_setting("bcf7_general", "bcf7_general_settings");
+    register_setting("bcf7_general", "bcf7_general_settings", array(
+      'sanitize_callback' => array($this, 'sanitize_options'),
+    ));
 
     add_settings_section(
       "bcf7_general_section",
@@ -59,6 +61,23 @@ class General
         "label_for" => "bcf7_redirect_page"
       )
     );
+  }
+
+  public function sanitize_options($input)
+  {
+    if (! is_array($input)) {
+      return array();
+    }
+
+    $clean = array();
+    $clean['bcf7_mode'] = (isset($input['bcf7_mode']) && '1' === (string) $input['bcf7_mode']) ? '1' : '';
+
+    $forms = isset($input['bcf7_form_select']) ? (array) $input['bcf7_form_select'] : array();
+    $clean['bcf7_form_select'] = array_values(array_filter(array_map('absint', $forms)));
+
+    $clean['bcf7_redirect_page'] = isset($input['bcf7_redirect_page']) ? absint($input['bcf7_redirect_page']) : 0;
+
+    return $clean;
   }
 
   public function mode_callback()

--- a/app/Settings/Validation.php
+++ b/app/Settings/Validation.php
@@ -18,18 +18,41 @@ class Validation
 
   public function credentials_check()
   {
-    if ("1" == $this->helpers->general_option("bcf7_mode") and ((empty($this->helpers->api_option("bcf7_sandbox_secret_key"))) or empty($this->helpers->api_option("bcf7_sandbox_collection_id")) or empty($this->helpers->api_option("bcf7_sandbox_xsignature_key")))) {
-      echo __(sprintf(
-        '<div class="notice notice-warning">
-              <p><strong>Billplz for Contact Form 7 -</strong>Billplz Sandbox Credentials is not set. Enter your Secret Key, Collection ID and X-Signature Key in order to use Billplz service. <a href="' . get_admin_url() . 'admin.php?page=billplz-cf7&tab=api-settings">Set Credential</a></p>
-          </div>',
-      ), BCF7_TEXT_DOMAIN);
-    } elseif ("0" == $this->helpers->general_option("bcf7_mode") and (empty($this->helpers->api_option("bcf7_live_secret_key")) or empty($this->helpers->api_option("bcf7_live_collection_id")) or empty($this->helpers->api_option("bcf7_live_xsignature_key")))) {
-      echo __(sprintf(
-        '<div class="notice notice-warning">
-              <p><strong>Billplz for Contact Form 7 -</strong>Billplz Live Credentials is not set. Enter your Secret Key, Collection ID and X-Signature Key in order to use Billplz service. <a href="' . get_admin_url() . 'admin.php?page=billplz-cf7&tab=api-settings">Set Credential</a></p>
-          </div>',
-      ), BCF7_TEXT_DOMAIN);
+    if (! current_user_can('manage_options')) {
+      return;
     }
+
+    $is_test_mode = ('1' === (string) $this->helpers->general_option('bcf7_mode'));
+
+    if ($is_test_mode) {
+      $missing = (
+        empty($this->helpers->api_option('bcf7_sandbox_secret_key'))
+        || empty($this->helpers->api_option('bcf7_sandbox_collection_id'))
+        || empty($this->helpers->api_option('bcf7_sandbox_xsignature_key'))
+      );
+      $message = __('Billplz Sandbox credentials are not set. Enter your Secret Key, Collection ID and X-Signature Key to use the Billplz service.', BCF7_TEXT_DOMAIN);
+    } else {
+      $missing = (
+        empty($this->helpers->api_option('bcf7_live_secret_key'))
+        || empty($this->helpers->api_option('bcf7_live_collection_id'))
+        || empty($this->helpers->api_option('bcf7_live_xsignature_key'))
+      );
+      $message = __('Billplz Live credentials are not set. Enter your Secret Key, Collection ID and X-Signature Key to use the Billplz service.', BCF7_TEXT_DOMAIN);
+    }
+
+    if (! $missing) {
+      return;
+    }
+
+    $url        = admin_url('admin.php?page=billplz-cf7&tab=api-settings');
+    $link_label = __('Set Credentials', BCF7_TEXT_DOMAIN);
+
+    printf(
+      '<div class="notice notice-warning"><p><strong>%1$s</strong> %2$s <a href="%3$s">%4$s</a></p></div>',
+      esc_html__('Billplz for Contact Form 7 -', BCF7_TEXT_DOMAIN),
+      esc_html($message),
+      esc_url($url),
+      esc_html($link_label)
+    );
   }
 }

--- a/assets/js/payment-redirect.js
+++ b/assets/js/payment-redirect.js
@@ -1,0 +1,14 @@
+(function () {
+  document.addEventListener('wpcf7submit', function (event) {
+    var detail = event.detail || {};
+    var response = detail.apiResponse || {};
+    var billplz = response.billplz || {};
+    var redirectUrl = typeof billplz.redirect_url === 'string' ? billplz.redirect_url : '';
+
+    if (detail.status !== 'payment_required' || !redirectUrl) {
+      return;
+    }
+
+    window.location.assign(redirectUrl);
+  }, false);
+}());

--- a/billplz-for-cf7.php
+++ b/billplz-for-cf7.php
@@ -9,7 +9,7 @@
  * Text Domain:     billplz-for-cf7
  * Domain Path:     /languages
  * Version:         1.3.0
- * License: GPL v2 or later
+ * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *
  * @package         Billplz_For_CF7

--- a/billplz-for-cf7.php
+++ b/billplz-for-cf7.php
@@ -8,7 +8,7 @@
  * Author URI:      https://alvindcaesar.com
  * Text Domain:     billplz-for-cf7
  * Domain Path:     /languages
- * Version:         1.2.1
+ * Version:         1.3.0
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *
@@ -26,7 +26,7 @@ define("BCF7_PLUGIN_URL", plugin_dir_url(__FILE__));
 define("BCF7_PLUGIN_FILE", plugin_basename(__FILE__));
 define("BCF7_ASSETS_URL", plugins_url('/billplz-for-contact-form-7/assets/'));
 define("BCF7_TEXT_DOMAIN", "billplz-for-cf7");
-define("BCF7_PLUGIN_VERSION", "1.2.1");
+define("BCF7_PLUGIN_VERSION", "1.3.0");
 
 if (class_exists('BillplzCF7\\Init')) {
   BillplzCF7\Init::register_services();

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Requires at least: 5.5
 Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 1.3.0
-License: GNU Version 2 or Any Later Version
+License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Integrates Billplz with Contact Form 7. Start accepting payment with Contact Form 7 & Billplz today.

--- a/readme.txt
+++ b/readme.txt
@@ -28,12 +28,16 @@ Payments are processed offsite at [Billplz](https://billplz.com) and the custome
 == Changelog ==
 
 = 1.3.0 - April 29, 2026 =
+* New: Failed payments now appear in the payments admin tab and have their own Failed view filter.
+* New: The example payment form created on activation is automatically selected as the active payment form.
 * Security: Verified Billplz signature inside the payment confirmation shortcode so crafted URLs can no longer expose another payer's details.
 * Security: Required a capability check and bulk-action nonce on the payments admin table before deleting or marking entries completed.
 * Security: Escaped the transaction ID link in the payments admin table.
 * Security: Verified the paid amount reported by Billplz against the recorded bill before marking a payment completed.
 * Security: Sanitized API, general, and email settings on save, including X-Signature key and email body input.
 * Security: Hardened the credentials notice to escape its admin URL and run a capability check.
+* Improvement: Payment redirect now works with Contact Form 7's Ajax submission flow.
+* Improvement: Billplz callback completion is now idempotent, so repeated callbacks cannot reprocess the same payment.
 * Improvement: Confirmation email now sends as HTML with the correct Content-Type header and escapes transaction placeholders.
 * Improvement: Payments admin table now uses the site timezone for the Submitted and Paid columns.
 * Fix: Stopped writing the 0000-00-00 zero datetime to paid_at, which failed under MySQL strict mode.

--- a/readme.txt
+++ b/readme.txt
@@ -4,9 +4,9 @@ Author URI: https://alvindcaesar.com
 Plugin URI: https://github.com/alvindcaesar/billplz-for-contact-form-7
 Tags: e-commerce, payment-gateway, product, subscription, payment-forms
 Requires at least: 5.5
-Tested up to: 6.8.1
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.2.1
+Stable tag: 1.3.0
 License: GNU Version 2 or Any Later Version
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,6 +26,18 @@ Payments are processed offsite at [Billplz](https://billplz.com) and the custome
 > 4. That's it. You are now ready to start accepting Billplz payment on your website through your contact form.
 
 == Changelog ==
+
+= 1.3.0 - April 29, 2026 =
+* Security: Verified Billplz signature inside the payment confirmation shortcode so crafted URLs can no longer expose another payer's details.
+* Security: Required a capability check and bulk-action nonce on the payments admin table before deleting or marking entries completed.
+* Security: Escaped the transaction ID link in the payments admin table.
+* Security: Verified the paid amount reported by Billplz against the recorded bill before marking a payment completed.
+* Security: Sanitized API, general, and email settings on save, including X-Signature key and email body input.
+* Security: Hardened the credentials notice to escape its admin URL and run a capability check.
+* Improvement: Confirmation email now sends as HTML with the correct Content-Type header and escapes transaction placeholders.
+* Improvement: Payments admin table now uses the site timezone for the Submitted and Paid columns.
+* Fix: Stopped writing the 0000-00-00 zero datetime to paid_at, which failed under MySQL strict mode.
+* Compatibility: Tested up to WordPress 6.9.
 
 = 1.2.1 - July 14, 2025 =
 * Security: Fixed XSS vulnerability in admin area payment table links.


### PR DESCRIPTION
## Summary
- Payment-flow improvements: CF7 Ajax redirect support, idempotent callback completion, failed payments in admin, auto-selected example form on activation.
- Post-audit security fixes: signature-verified confirmation shortcode, capability + bulk-action nonce on the payments admin table, escaped admin table link, paid-amount verification, sanitized API/general/email settings, hardened credentials notice.
- Email confirmation now sends as HTML with the correct Content-Type and escapes transaction placeholders.
- MySQL strict-mode compatibility: paid_at no longer written as 0000-00-00; raw NULL writes used to stay compatible with WordPress 5.5+.
- Tested up to WordPress 6.9. Plugin version bumped to 1.3.0.

## Test plan
- [x] Activate plugin on a fresh site; verify confirmation page and example form are created and the example form is preselected.
- [x] Submit the example form via Ajax in a CF7 page and confirm redirect to Billplz.
- [ ] Complete a sandbox payment; verify payment row marked completed and confirmation email arrives rendered as HTML with escaped placeholders.
- [x] Refresh the redirect page after completion; PII still renders for the signed URL only.
- [x] Visit the redirect page with a tampered signature or someone else's payment-id; expect "Invalid or expired" message.
- [ ] Try a bulk delete or mark-as-completed without a valid nonce or as a non-admin; expect rejection.
- [ ] Save API, General, and Email settings with mixed input; confirm sanitized values are stored.
- [ ] Run on MySQL with strict mode + NO_ZERO_DATE through a full payment lifecycle.
- [x] Confirm Failed status filter shows failed payments in the admin payments view.

Do **not** merge to master until testing on this branch is signed off.